### PR TITLE
Improve matchThemesWithSentiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+dist/

--- a/dist/functions/match-themes-with-sentiment.js
+++ b/dist/functions/match-themes-with-sentiment.js
@@ -1,17 +1,30 @@
 import { getEmbedding, knex } from "../connector.js";
 export const matchThemesWithSentiment = async (text) => {
     if (!text)
-        throw new Error("Must provide input text");
+        throw new Error('Must provide input text');
     const embedding = await getEmbedding(text);
-    const results = await knex
-        .select({
-        category: "categories.name",
-        sentiment: "sentiments.name",
-        distance: knex.raw("(categories.embedding + sentiments.embedding) <=> ?", [embedding]),
+    const results = await knex.with('distances', knex.select({
+        category: 'categories.name',
+        sentiment: 'sentiments.name',
+        distance: knex.raw('(categories.embedding + sentiments.embedding) <=> ?', [embedding])
     })
-        .from("categories")
-        .crossJoin(knex.raw("sentiments"))
-        .orderBy("distance", "asc")
+        .from('categories')
+        .crossJoin(knex.raw('sentiments'))
+        .orderBy('distance', 'asc'))
+        .with('min_distances', knex.select({
+        category: 'category',
+        distance: knex.raw('MIN(distance)'),
+    })
+        .from('distances')
+        .groupBy('category'))
+        .select({
+        category: 'min_distances.category',
+        sentiment: 'distances.sentiment',
+        distance: 'min_distances.distance',
+    })
+        .from('min_distances')
+        .join('distances', 'min_distances.distance', 'distances.distance')
+        .orderBy('distance', 'asc')
         .limit(5);
     console.table(results);
 };

--- a/src/functions/match-themes-with-sentiment.ts
+++ b/src/functions/match-themes-with-sentiment.ts
@@ -1,21 +1,35 @@
 import { getEmbedding, knex } from "../connector.js";
 
 export const matchThemesWithSentiment = async (text: string) => {
-  if (!text) throw new Error("Must provide input text");
-  const embedding = await getEmbedding(text);
-  const results = await knex
-    .select({
-      category: "categories.name",
-      sentiment: "sentiments.name",
-      distance: knex.raw(
-        "(categories.embedding + sentiments.embedding) <=> ?",
-        [embedding]
-      ),
-    })
-    .from("categories")
-    .crossJoin(knex.raw("sentiments"))
-    .orderBy("distance", "asc")
-    .limit(5);
-
-  console.table(results);
+  if (!text) throw new Error('Must provide input text');
+    const embedding = await getEmbedding(text);
+    const results = await knex.with('distances',
+        knex.select({
+            category: 'categories.name',
+            sentiment: 'sentiments.name',
+            distance: knex.raw('(categories.embedding + sentiments.embedding) <=> ?', [embedding])
+        })
+        .from('categories')
+        .crossJoin(knex.raw('sentiments'))
+        .orderBy('distance', 'asc')
+    )
+     .with('min_distances',
+        knex.select({
+            category: 'category',
+            distance: knex.raw('MIN(distance)'),
+        })
+        .from('distances')
+        .groupBy('category')
+     )
+     .select({
+        category: 'min_distances.category',
+        sentiment: 'distances.sentiment',
+        distance: 'min_distances.distance',
+     })
+     .from('min_distances')
+     .join('distances', 'min_distances.distance', 'distances.distance')
+     .orderBy('distance', 'asc')
+     .limit(5);
+        
+    console.table(results);
 };


### PR DESCRIPTION
The simple query to match themes and sentiments was producing multiple instances of a single theme with different sentiments. This modifies the query to pick only one sentiment for each theme.